### PR TITLE
Add configuration option for TERM environment variable

### DIFF
--- a/conf.h
+++ b/conf.h
@@ -10,6 +10,9 @@
 #define EDITOR		{"vi"}
 #define MAIL		{"mailx", "-f", "+inbox"}
 
+/* TERM variable for launched programs */
+#define TERM        "linux"
+
 /* fbval_t should match framebuffer depth */
 typedef unsigned int fbval_t;
 

--- a/term.c
+++ b/term.c
@@ -341,7 +341,7 @@ void term_exec(char **args)
 	if ((term->pid = fork()) == -1)
 		return;
 	if (!term->pid) {
-		char *envp[MAXENV] = {"TERM=linux"};
+		char *envp[MAXENV] = {"TERM=" TERM};
 		envcpy(envp + 1, environ);
 		_login(slave);
 		close(master);


### PR DESCRIPTION
The TERM environment variable for launched programs (shell, editor) was hardcoded as "linux" in `term.c`. Now it can be set in the `conf.h` (default remains "linux").

In my opinion, this is much nicer because you don't have to add `export TERM=...` to your shell rc any more. This is especially useful for me as I sometimes use the plain vconsole and sometimes urxvt under Xorg.