### PR TITLE
term:

### DIFF
--- a/term.c
+++ b/term.c
@@ -329,11 +329,11 @@ static void envcpy(char **d, char **s)
 	int i = 0, j = 0;
 	while (s[i] && j < MAXENV - 2) {
 		d[j] = s[i++];
-		if (!memcmp(d[j], "TERM=", 5))
+		if (memcmp(d[j], "TERM=", 5))
 			j++;
 	}
 	d[j++] = "TERM=" TERM;
-	d[j++] = NULL;
+	d[j] = NULL;
 }
 
 extern char **environ;


### PR DESCRIPTION
envcpy(...) does not copy environ since memcmp() signals succes by returning 0 which means 'false' in C (and incrementing a local variable at the end of a block has probably no effect)