### PR TITLE
term: fix BRIGHTEN

### DIFF
--- a/term.c
+++ b/term.c
@@ -1221,9 +1221,8 @@ static void csiseq(void)
 			setattr(args[i]);
 		}
 		if (mode & MODE_CLR8 && mode & ATTR_BOLD && BRIGHTEN)
-			for (i = 0; i < 8; i++)
-				if (clr16[i] == fg)
-					fg = clr16[8 + i];
+			if (fg < 8)
+				fg += 8
 		break;
 	case 'r':	/* DECSTBM	set scrolling region to (top, bottom) rows */
 		set_region(args[0], args[1]);


### PR DESCRIPTION
Hi, so I wanted to play NetHack without an X server. And NetHack uses ATTR_BOLD to select the top colors (from 8 to F). BRIGHTEN was broken. Now it isn't.